### PR TITLE
remove unused lodash debounce import from HomeContent.vue

### DIFF
--- a/frontend/src/views/HomeContent.vue
+++ b/frontend/src/views/HomeContent.vue
@@ -148,7 +148,6 @@ import EditModalContent from "./EditModalContent.vue";
 //add spinner
 import SpinnerContent from "../components/SpinnerContent.vue";
 //import debounce
-import { debounce } from "lodash";
 
 const store = useStore();
 const showModal = ref(false);


### PR DESCRIPTION
### **PR Type**
Other


___

### **Description**
- Remove unused lodash debounce import from HomeContent.vue


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>HomeContent.vue</strong><dd><code>Remove unused lodash debounce import</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/views/HomeContent.vue

- Removed unused `debounce` import from lodash library


</details>


  </td>
  <td><a href="https://github.com/kanorssss/testing/pull/9/files#diff-e90ab7e3e2f3b9bfa5b8def78f920c472f16bf4ab558a02df0da70cde3d0b218">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>